### PR TITLE
Add deployment scripts for keycloak

### DIFF
--- a/infra/app/content-api.bicep
+++ b/infra/app/content-api.bicep
@@ -63,6 +63,17 @@ resource applicationService 'Microsoft.App/containerApps@2025-01-01' = {
           value: gmailServiceAccountCredentials
         }
       ]
+      ingress: {
+        external: true
+        targetPort: 8080
+        allowInsecure: false
+        traffic: [
+          {
+            weight: 100
+            latestRevision: true
+          }
+        ]
+      }
     }
     template: {
       containers: [
@@ -117,3 +128,6 @@ resource applicationService 'Microsoft.App/containerApps@2025-01-01' = {
     }
   }
 }
+
+output name string = applicationService.name
+output fqdn string = applicationService.properties.configuration.ingress.fqdn

--- a/infra/app/keycloak.bicep
+++ b/infra/app/keycloak.bicep
@@ -1,0 +1,149 @@
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param containerAppsEnvironmentName string
+param databaseServerDomainName string
+param databaseServerAdminUsername string
+@secure()
+param databaseServerAdminPassword string
+@secure()
+param keycloakAdminPassword string
+param keycloakAdminUsername string = 'admin'
+
+var databaseUrl = 'jdbc:postgresql://${databaseServerDomainName}:5432/keycloak?sslmode=require'
+
+resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2025-02-02-preview' existing = {
+  name: containerAppsEnvironmentName
+}
+
+resource keycloakApp 'Microsoft.App/containerApps@2025-01-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'service-name': 'keycloak' })
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    configuration: {
+      secrets: [
+        {
+          name: 'database-password'
+          value: databaseServerAdminPassword
+        }
+        {
+          name: 'keycloak-admin-password'
+          value: keycloakAdminPassword
+        }
+      ]
+      ingress: {
+        external: true
+        targetPort: 8080
+        allowInsecure: false
+        traffic: [
+          {
+            weight: 100
+            latestRevision: true
+          }
+        ]
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'keycloak'
+          image: 'quay.io/keycloak/keycloak:26.2.4'
+          resources: {
+            cpu: 1
+            memory: '2Gi'
+          }
+          args: [
+            'start'
+            '--optimized'
+          ]
+          env: [
+            {
+              name: 'KC_HOSTNAME_STRICT'
+              value: 'false'
+            }
+            {
+              name: 'KC_HOSTNAME_STRICT_HTTPS'
+              value: 'false'
+            }
+            {
+              name: 'KC_HTTP_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'KC_PROXY'
+              value: 'edge'
+            }
+            {
+              name: 'KC_DB'
+              value: 'postgres'
+            }
+            {
+              name: 'KC_DB_URL'
+              value: databaseUrl
+            }
+            {
+              name: 'KC_DB_USERNAME'
+              value: databaseServerAdminUsername
+            }
+            {
+              name: 'KC_DB_PASSWORD'
+              secretRef: 'database-password'
+            }
+            {
+              name: 'KEYCLOAK_ADMIN'
+              value: keycloakAdminUsername
+            }
+            {
+              name: 'KEYCLOAK_ADMIN_PASSWORD'
+              secretRef: 'keycloak-admin-password'
+            }
+            {
+              name: 'KC_HEALTH_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'KC_METRICS_ENABLED'
+              value: 'true'
+            }
+          ]
+          probes: [
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/health/live'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 60
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/health/ready'
+                port: 8080
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 30
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 2
+      }
+    }
+  }
+}
+
+output name string = keycloakApp.name
+output fqdn string = keycloakApp.properties.configuration.ingress.fqdn
+output url string = 'https://${keycloakApp.properties.configuration.ingress.fqdn}'

--- a/infra/core/database/postgres.bicep
+++ b/infra/core/database/postgres.bicep
@@ -46,6 +46,10 @@ resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2025-01-01-pr
     name: 'temporal_visibility'
   }
 
+  resource keycloakDatabase 'databases' = {
+    name: 'keycloak'
+  }
+
   resource allowInternalAddressess 'firewallRules' = {
     name: 'AllowInternalAddresses'
     properties: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,6 +19,11 @@ param dashboardImageName string
 param gmailServiceAccountCredentials string
 param buzzsproutApiKey string
 param buzzsproutPodcastId string
+@secure()
+param keycloakAdminPassword string
+param keycloakAdminUsername string = 'admin'
+@secure()
+param keycloakDashboardClientSecret string
 
 var tags = {
   'env-name': environmentName
@@ -160,6 +165,24 @@ module dashboardApp './app/dashboard.bicep' = {
     imageName: dashboardImageName
     serviceName: 'dashboard'
     name: 'dashboard'
+    location: location
+    tags: tags
+    keycloakUrl: keycloakApp.outputs.url
+    keycloakClientSecret: keycloakDashboardClientSecret
+    contentApiUrl: 'https://${contentApi.outputs.fqdn}/graphql'
+  }
+}
+
+module keycloakApp './app/keycloak.bicep' = {
+  name: 'keycloak-app'
+  params: {
+    containerAppsEnvironmentName: containerAppsEnvironmentName
+    databaseServerDomainName: databaseServer.outputs.domainName
+    databaseServerAdminUsername: databaseServerAdminLogin
+    databaseServerAdminPassword: databaseServerAdminPassword
+    keycloakAdminPassword: keycloakAdminPassword
+    keycloakAdminUsername: keycloakAdminUsername
+    name: 'keycloak'
     location: location
     tags: tags
   }

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -17,6 +17,9 @@ param databaseServerAdminPassword = readEnvironmentVariable('DATABASE_ADMIN_PASS
 param gmailServiceAccountCredentials = readEnvironmentVariable('GMAIL_SERVICE_ACCOUNT_CREDENTIALS') 
 param buzzsproutApiKey = readEnvironmentVariable('BUZZSPROUT_API_KEY')
 param buzzsproutPodcastId = readEnvironmentVariable('BUZZSPROUT_PODCAST_ID')
+param keycloakAdminPassword = readEnvironmentVariable('KEYCLOAK_ADMIN_PASSWORD')
+param keycloakAdminUsername = readEnvironmentVariable('KEYCLOAK_ADMIN_USERNAME', 'admin')
+param keycloakDashboardClientSecret = readEnvironmentVariable('KEYCLOAK_DASHBOARD_CLIENT_SECRET')
 
 // The image names are derived from the container registry and a GIT hash that we set in the CI/CD pipeline.
 param contentApiImageName = '${containerRegistryName}.azurecr.io/newscast/content-api:1.0.0-${imageHash}'


### PR DESCRIPTION
Includes a keycloak container app configuration with associated database connection. Connects the frontend to the content API with authentication support through keycloak.